### PR TITLE
Support Systems without GLOB_BRACE (e.g. musl)

### DIFF
--- a/operator/image.php
+++ b/operator/image.php
@@ -41,7 +41,7 @@ class image extends operator implements image_interface
 	 * Set up the operator.
 	 *
 	 * @param \phpbb\filesystem\filesystem_interface $filesystem
-	 * @param string								 $img_path		The path to the custom images
+	 * @param string                                 $img_path      The path to the custom images
 	 */
 	public function setup(filesystem_interface $filesystem, $img_path)
 	{
@@ -89,18 +89,19 @@ class image extends operator implements image_interface
 	public function get_images()
 	{
 		$images = array();
+
 		$handle = opendir($this->img_path);
-		if ($handle === false) 
+		if ($handle === false)
 		{
 			trigger_error("Could not open: '$this->img_path'", E_USER_ERROR);
-		} 
+		}
 		else
 		{
 			while (false !== ($file = readdir($handle)))
 			{
 				$file = $this->img_path . $file;
 				$ext = substr($file, strrpos($file, '.'));
-				switch(strtolower($ext))
+				switch (strtolower($ext))
 				{
 					case '.svg':
 						$images[] = basename($file);
@@ -119,7 +120,9 @@ class image extends operator implements image_interface
 						break; // Unknown extension
 				}
 			}
+			closedir($handle);
 		}
+
 		return $images;
 	}
 

--- a/operator/image.php
+++ b/operator/image.php
@@ -12,6 +12,7 @@ namespace stevotvr\flair\operator;
 
 use phpbb\filesystem\filesystem_interface;
 use stevotvr\flair\exception\base;
+use Zend\Stdlib\Glob;
 
 /**
  * Profile Flair image operator.
@@ -90,7 +91,7 @@ class image extends operator implements image_interface
 	{
 		$images = array();
 
-		foreach (glob($this->img_path . '*{-x1.{gif,png,jpg,jpeg,GIF,PNG,JPG,JPEG},.{svg,SVG}}', GLOB_BRACE) as $file)
+		foreach (Glob::glob($this->img_path . '*{-x1.{gif,png,jpg,jpeg,GIF,PNG,JPG,JPEG},.{svg,SVG}}', Glob::GLOB_BRACE) as $file)
 		{
 			$ext = substr($file, strrpos($file, '.'));
 			if (strtolower($ext) === '.svg')
@@ -151,7 +152,7 @@ class image extends operator implements image_interface
 		}
 		else
 		{
-			if (count(glob($this->img_path . $name . '-x[123]' . $ext)) > 0)
+			if (count(Glob::glob($this->img_path . $name . '-x[123]' . $ext)) > 0)
 			{
 				throw new base('EXCEPTION_IMG_CONFLICT');
 			}
@@ -178,7 +179,7 @@ class image extends operator implements image_interface
 		else
 		{
 			$name = substr($name, 0, strrpos($name, '.'));
-			$this->filesystem->remove(glob($this->img_path . $name . '-x[123]' . $ext));
+			$this->filesystem->remove(Glob::glob($this->img_path . $name . '-x[123]' . $ext));
 		}
 	}
 


### PR DESCRIPTION
Some Systems (e.g. alpine) do not support GLOB_BRACE directly. This will cause dependend implementation to fail as GLOB_BRACE will not be defined. This is fixed by using Stdlib from the Zend Framework, bundled with the current phpBB distribution. Systems with direct support of GLOB_BRACE should not be affected by this, as it will automatically be used if available.

Without this change affected systems might run into corruption of the autoloader used by the acp until manually deleting the cache inside the phpbb installation.

Since i haven't used phpbb in a long time, im not sure this is everything that is needed. Applying this solution can also be a temporary workaround for Version 1.1, as no major changes have been made. This should be every occasion of glob. I did not however add zen lib as a dependency, because it is already provided by phpBB and i didn't want to touch the build files, if required.